### PR TITLE
Fixes post streams

### DIFF
--- a/index.js
+++ b/index.js
@@ -34,7 +34,13 @@ function SnooStream (options, drift = 0) {
     return poll;
   }
   function parse (data, emitter, regex) {
-    const match = data.body.match(regex);
+    let match;
+    if (data.hasOwnProperty('body')) {
+      match = data.body.match(regex);
+    } else if (data.hasOwnProperty('selftext')) {
+      match = data.selftext.match(regex);
+    }
+
     if (match) {
       emitter.emit('post', data, match);
     }


### PR DESCRIPTION
Currently, SnooStream.Submission objects contain no 'body' property, causing all submission streams to error out.  This adds a check to the parse() function to determine if it is a post and should regex the 'selftext' property or the 'body' property if it is a comment.